### PR TITLE
jwt validation, will later implement checking the expiration

### DIFF
--- a/server/src/controllers/puffs/router.js
+++ b/server/src/controllers/puffs/router.js
@@ -1,8 +1,10 @@
-
 import * as express from 'express';
 import Multer from 'multer';
 import fs from 'fs-extra';
 import puff from './puff';
+import {
+  validateToken,
+} from '../../services/jwt';
 
 const multerStorage = Multer.diskStorage({
   destination: function (req, file, cb) {
@@ -21,7 +23,7 @@ const multerStorage = Multer.diskStorage({
 });
 
 const multerFilefilter = (req, file, cb) => {
-  //reject file
+  // reject file
   if (file.mimetype === 'image/jpeg' || file.mimetype === 'image/png') {
     cb(null, true);
   } else {
@@ -39,10 +41,10 @@ const multerUpload = Multer({
 
 export default express
   .Router()
-  .post('/', puff.create)
-  .post('/u', multerUpload.single('upload'), puff.createWithFile)
-  .put('/u/:id', multerUpload.single('upload'), puff.updateWithFile)
-  .put('/:id', puff.update)
-  .get('/', puff.list)
-  .get('/:id', puff.get)
-  .delete('/:id', puff.remove);
+  .post('/', validateToken, puff.create)
+  .post('/u', validateToken, multerUpload.single('upload'), puff.createWithFile)
+  .put('/u/:id', validateToken, multerUpload.single('upload'), puff.updateWithFile)
+  .put('/:id', validateToken, puff.update)
+  .get('/', validateToken, puff.list)
+  .get('/:id', validateToken, puff.get)
+  .delete('/:id', validateToken, puff.remove);

--- a/server/src/controllers/users/router.js
+++ b/server/src/controllers/users/router.js
@@ -1,15 +1,16 @@
 import * as express from 'express';
 import user from './user';
 import {
-  createUserSchema
+  validateToken,
+} from '../../services/jwt';
+import {
+  createUserSchema,
 } from '../../schemas';
 
 export default express
   .Router()
-  .post('/',
-    createUserSchema,
-    user.create)
-  .put('/:id', user.update)
-  .get('/', user.list)
-  .get('/:id', user.get)
-  .delete('/:id', user.remove);
+  .post('/', createUserSchema, user.create)
+  .put('/:id', validateToken, user.update)
+  .get('/', validateToken, user.list)
+  .get('/:id', validateToken, user.get)
+  .delete('/:id', validateToken, user.remove);

--- a/server/src/services/jwt.js
+++ b/server/src/services/jwt.js
@@ -1,7 +1,50 @@
 const jwt = require('jwt-simple');
 const moment = require('moment');
 
-exports.createToken = function (user) {
+exports.validateToken = (req, res, next) => {
+  let token = '';
+  if (req.headers.authorization && req.headers.authorization.split(' ')[0] === 'Bearer') { // Authorization: Bearer g1jipjgi1ifjioj
+    // Handle token presented as a Bearer token in the Authorization header
+    token = req.headers.authorization.split(' ')[1];
+  } else if (req.headers['x-jc-token']) {
+    token = req.headers['x-jc-token'];
+  } else if (req.query && req.query.token) {
+    // Handle token presented as URI param
+    token = req.query.token;
+  } else if (req.cookies && req.cookies.token) {
+    // Handle token presented as a cookie parameter
+    token = req.cookies.token;
+  }
+  // If we return null, we couldn't find a token.
+  // In this case, the JWT middleware will return a 401 (unauthorized)
+  // to the client for this request
+  if (!token) {
+    req.log.error('Unauthorized: Token not found');
+    res.status(401)
+      .send({
+        message: 'Unauthorized: Token not found',
+      });
+  } else {
+    try {
+      jwt.decode(token, process.env.SESSION_SECRET);
+    } catch (e) {
+      res.status(401)
+        .send({
+          message: 'Unauthorized: Invalid token',
+        });
+      return;
+    }
+
+    /* if (!tokens.isValid(token)) {
+      res.statusMessage = 'Unauthorized : Token is either invalid or expired';
+      res.sendStatus('401');
+      return;
+    } */
+    next();
+  }
+};
+
+exports.createToken = user => {
   let scopes;
   // Check if the user object passed in
   // has admin set to true, and if so, set
@@ -24,10 +67,7 @@ exports.createToken = function (user) {
     exp: moment()
       .add(30, 'days')
       .unix(),
-    scope: scopes
+    scope: scopes,
   };
   return jwt.encode(payload, process.env.SESSION_SECRET);
-};
-
-exports.validateToken = function (req, res, next) {
 };


### PR DESCRIPTION
I used some of the code from https://gist.github.com/thebigredgeek/230368bd92aa19e3f6638b659edf5cef to implement the validation of the current token created by the backend, but right now is not checking for the expiration of the token.  I can do that later, but for now this is good.

From Slack:
"Fernando Ortiz [11:54 PM]
I got JWT to work.  I can login and using that token then I can call the other operations without the token it won’t work.

from your side you just need to make sure the token is send back to the backend, as a `req.headers.authorization` using Bearer, or as a `req.query.token`, or as cookie with `req.cookies.token` or as a header with `x-jc-token`.

Fernando Ortiz [12:09 AM]
The only methods not checking for the token is `auth/login` and `users/create`"

-    As before if you want to test this code, please delete new branch after testing the code.  Make a new branch from your current code if working on a topic branch then merge this branch or pull request onto that new branch.
-    Run backend with `yarn run dev` then register/create a new user or login an existing user, capture the token then using portman make sure to send a header `Authentication: Bearer TOKEN` or pass `x-jc-token: TOKEN` or a `token` as cookie, or a `token` as a string query.  If you want to use the front end you need to pass any of those to Axios first.

