### PR TITLE
Enhancements/favorites

### DIFF
--- a/client/src/components/Feed.vue
+++ b/client/src/components/Feed.vue
@@ -23,7 +23,6 @@
           </button>    
           <i class="fa fa-heart fa-lg" role="button"
             @click="showPuff(puffObject)" aria-hidden="true">
-            <strong class="fav-text">{{ puffObject.meta.favs }}</strong>
           </i>
           <hr/>
         </div>
@@ -100,11 +99,5 @@ export default {
 .fa-heart:hover {
   color: #d50000;
   cursor: pointer;
-}
-.fav-text {
-  font-family: "Roboto";
-  color: #000;
-  font-size: 14px;
-  padding-left: 5px;
 }
 </style>

--- a/client/src/components/Feed.vue
+++ b/client/src/components/Feed.vue
@@ -36,7 +36,7 @@ export default {
   name: "feed",
   props: ["puffs"],
   mounted: function() {
-    console.log("The Feed component has been mounted");
+    //console.log("The Feed component has been mounted");
   },
   data: function() {
     return {

--- a/client/src/components/Feed.vue
+++ b/client/src/components/Feed.vue
@@ -23,7 +23,7 @@
           </button>    
           <i class="fa fa-heart fa-lg" role="button"
             @click="showPuff(puffObject)" aria-hidden="true"
-            v-if="favMode(puffObject.favs)" :class="{unfav: !favStatus}">
+            :class="{unfav: !puffObject.favs}">
           </i>
           <hr/>
         </div>
@@ -41,27 +41,12 @@ export default {
   },
   data: function() {
     return {
-      userPuffs: [],
-      puff: {
-        id: "",
-        title: "",
-        content: ""
-      },
-      // Used to display grey colored heart if value evaluates to false
-      favStatus: true
+      userPuffs: []
     };
   },
   methods: {
     loadPuffs(puffs) {
       this.userPuffs = puffs;
-    },
-    favMode(favVal) {
-      if (favVal > 0) {
-        this.favStatus = true;
-      } else {
-        this.favStatus = false;
-      }
-      return true;
     },
     frameUrl(imageUrl) {
       if (imageUrl) {

--- a/client/src/components/Feed.vue
+++ b/client/src/components/Feed.vue
@@ -22,7 +22,8 @@
             <i class="fa fa-trash" aria-hidden="true"></i>
           </button>    
           <i class="fa fa-heart fa-lg" role="button"
-            @click="showPuff(puffObject)" aria-hidden="true">
+            @click="showPuff(puffObject)" aria-hidden="true"
+            v-if="favMode(puffObject.favs)" :class="{unfav: !favStatus}">
           </i>
           <hr/>
         </div>
@@ -45,12 +46,22 @@ export default {
         id: "",
         title: "",
         content: ""
-      }
+      },
+      // Used to display grey colored heart if value evaluates to false
+      favStatus: true
     };
   },
   methods: {
-    loadPuffs: function(puffs) {
+    loadPuffs(puffs) {
       this.userPuffs = puffs;
+    },
+    favMode(favVal) {
+      if (favVal > 0) {
+        this.favStatus = true;
+      } else {
+        this.favStatus = false;
+      }
+      return true;
     },
     frameUrl(imageUrl) {
       if (imageUrl) {
@@ -94,10 +105,13 @@ export default {
 }
 .fa-heart {
   padding-top: 10px;
-  color: red;
+  color: #ff0000;
 }
 .fa-heart:hover {
   color: #d50000;
   cursor: pointer;
+}
+.unfav {
+  color: #c3c3c3;
 }
 </style>

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -17,8 +17,8 @@
             <p>{{ fileName }}</p>
             <i class="fa fa-heart fa-lg" role="button"
               @click.prevent="updateFavs" aria-hidden="true"
-              v-if="editMode" v-model="favs">
-              <strong class="fav-text">{{ favs }}</strong>
+              v-if="editMode" :class="{unfav: !favStatus}" v-model="favs">
+              <strong>{{ this.favs }}</strong>
             </i>
             <div v-if="puffImage">
               <img :src="frameUrl(puffImage)" width="100px"/>
@@ -77,6 +77,7 @@ export default {
       puffsPage: 0,
       errorMessage: "",
       show: false,
+      favStatus: true,
       selectedFile: null,
       fileName: null,
       editMode: false,
@@ -102,8 +103,10 @@ export default {
       if (this.$store.getters.getUserId === this.puffAuthor) {
         if (this.favs === 1) {
           this.favs = 0;
+          this.favStatus = false;
         } else if (this.favs === 0) {
           this.favs = 1;
+          this.favStatus = true;
         }
       } else {
         this.favs += 1;
@@ -169,9 +172,11 @@ export default {
       this.puffImage = puffObject.image;
       this.puffAuthor = puffObject.author;
       if (puffObject.favs > 0) {
+        this.favStatus = true;
         this.favs = puffObject.favs;
       } else {
         this.favs = 0;
+        this.favStatus = false;
       }
     },
     async editPuff() {
@@ -320,7 +325,10 @@ input {
 }
 .fa-heart {
   padding-bottom: 10px;
-  color: red;
+  color: #ff0000;
+}
+.unfav {
+  color: #c3c3c3;
 }
 .fa-heart:hover {
   color: #d50000;

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -100,7 +100,11 @@ export default {
     },
     updateFavs() {
       if (this.$store.getters.getUserId === this.puffAuthor) {
-        this.favs = 1;
+        if (this.favs === 1) {
+          this.favs = 0;
+        } else if (this.favs === 0) {
+          this.favs = 1;
+        }
       } else {
         this.favs += 1;
       }

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -17,8 +17,7 @@
             <p>{{ fileName }}</p>
             <i class="fa fa-heart fa-lg" role="button"
               @click.prevent="updateFavs" aria-hidden="true"
-              v-if="editMode" :class="{unfav: !favStatus}" v-model="favs">
-              <strong>{{ this.favs }}</strong>
+              v-if="editMode" :class="{unfav: !favStatus}">
             </i>
             <div v-if="puffImage">
               <img :src="frameUrl(puffImage)" width="100px"/>

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -158,25 +158,22 @@ export default {
       this.puffContent = puffObject.content;
       this.puffImage = puffObject.image;
       this.puffAuthor = puffObject.author;
-      if (puffObject.meta.favs > 0) {
-        this.favs = puffObject.meta.favs;
+      if (puffObject.favs > 0) {
+        this.favs = puffObject.favs;
       } else {
         this.favs = 0;
       }
     },
     async editPuff() {
       let self = this;
-      let meta = {
-        favs: self.favs
-      };
       if (self.selectedFile != null) {
         try {
           const fd = new FormData();
           fd.append("title", self.puffTitle);
           fd.append("content", self.puffContent);
           fd.append("upload", self.selectedFile);
-          if (self.favs > 0) {
-            fd.append("meta", meta);
+          if (self.favs) {
+            fd.append("favs", self.favs);
           }
           await PuffService.updatePuffWithImage(
             self.puffId,
@@ -193,7 +190,7 @@ export default {
           content: self.puffContent
         };
         if (self.favs > 0) {
-          updateObj.meta = meta;
+          updateObj.favs = self.favs;
         }
         try {
           await PuffService.updatePuff(

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -17,7 +17,7 @@
             <p>{{ fileName }}</p>
             <i class="fa fa-heart fa-lg" role="button"
               @click.prevent="updateFavs" aria-hidden="true"
-              v-if="editMode" :class="{unfav: !favStatus}">
+              v-if="editMode" :class="{unfav: !favs}">
             </i>
             <div v-if="puffImage">
               <img :src="frameUrl(puffImage)" width="100px"/>
@@ -76,7 +76,6 @@ export default {
       puffsPage: 0,
       errorMessage: "",
       show: false,
-      favStatus: true,
       selectedFile: null,
       fileName: null,
       editMode: false,
@@ -102,10 +101,8 @@ export default {
       if (this.$store.getters.getUserId === this.puffAuthor) {
         if (this.favs === 1) {
           this.favs = 0;
-          this.favStatus = false;
         } else if (this.favs === 0) {
           this.favs = 1;
-          this.favStatus = true;
         }
       } else {
         this.favs += 1;
@@ -171,11 +168,9 @@ export default {
       this.puffImage = puffObject.image;
       this.puffAuthor = puffObject.author;
       if (puffObject.favs > 0) {
-        this.favStatus = true;
         this.favs = puffObject.favs;
       } else {
         this.favs = 0;
-        this.favStatus = false;
       }
     },
     async editPuff() {

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -18,7 +18,6 @@
             <i class="fa fa-heart fa-lg" role="button"
               @click.prevent="updateFavs" aria-hidden="true"
               v-if="editMode" v-model="favs">
-              <strong class="fav-text">{{ favs }}</strong>
             </i>
             <div v-if="puffImage">
               <img :src="frameUrl(puffImage)" width="100px"/>
@@ -311,11 +310,5 @@ input {
 .fa-heart:hover {
   color: #d50000;
   cursor: pointer;
-}
-.fav-text {
-  font-family: "Roboto";
-  color: #000;
-  font-size: 14px;
-  padding: 0 10px 0 5px;
 }
 </style>

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -39,8 +39,8 @@
             </button>
             <div v-if="show">
               <p class="error">
-              <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
-              {{ error }}</p>
+              <!-- <i class="fa fa-exclamation-circle" aria-hidden="true"></i> -->
+              {{ errorMessage }}</p>
             </div>
             <div v-if="successMessage" class="alert alert-success">
               {{ successMessage }}
@@ -75,7 +75,7 @@ export default {
       puffAuthor: "",
       userPuffs: [],
       puffsPage: 0,
-      error: null,
+      errorMessage: "",
       show: false,
       selectedFile: null,
       fileName: null,
@@ -111,6 +111,12 @@ export default {
         this.successMessage = "";
       }, 4000);
     },
+    error(message) {
+      this.errorMessage = message;
+      setTimeout(() => {
+        this.errorMessage = "";
+      }, 5000);
+    },
     async createNewPuff() {
       let self = this;
       if (self.selectedFile != null) {
@@ -126,7 +132,7 @@ export default {
           );
           this.success("Puff created successfully.");
         } catch (error) {
-          (this.show = true), (this.error = error.response.data.error);
+          (this.show = true), this.error(error.response.data.error);
         }
       } else {
         try {
@@ -140,7 +146,7 @@ export default {
           );
           this.success("Puff created successfully.");
         } catch (error) {
-          (this.show = true), (this.error = error.response.data.error);
+          (this.show = true), this.error(error.response.data.error);
         }
       }
       // Reloads feed section
@@ -182,7 +188,7 @@ export default {
           );
           this.success("Puff updated successfully.");
         } catch (error) {
-          (this.show = true), (this.error = error.response.data.error);
+          (this.show = true), this.error(error.response.data.error);
         }
       } else {
         let updateObj = {
@@ -200,7 +206,7 @@ export default {
           );
           this.success("Puff updated successfully.");
         } catch (error) {
-          (this.show = true), (this.error = error.response.data.error);
+          (this.show = true), this.error(error.response.data.error);
         }
       }
       // Reloads feed section
@@ -236,7 +242,7 @@ export default {
           this.success("Puff deleted successfully.");
         }
       } catch (error) {
-        (this.show = true), (this.error = error.response.data.error);
+        (this.show = true), this.error(error.response.data.error);
       }
       // Refreshes the feed content
       this.readUserPuffs();
@@ -249,7 +255,7 @@ export default {
         );
         this.userPuffs = response.data.user.puffs;
       } catch (error) {
-        (this.show = true), (this.error = error.response.data.error);
+        (this.show = true), this.error(error.response.data.error);
       }
     },
     loadInformationFromLocalStorage: function() {
@@ -300,6 +306,7 @@ input {
   font-size: 14px;
   letter-spacing: 1px;
   padding-bottom: 5px;
+  color: red;
 }
 .alert {
   margin-top: 10px;

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -11,13 +11,14 @@
               @change="onFileSelected"
               ref="fileInput">
             <button class="btn btn-custom" 
-              @click="$refs.fileInput.click()">
+              @click.prevent="$refs.fileInput.click()">
               Select File
             </button>
             <p>{{ fileName }}</p>
             <i class="fa fa-heart fa-lg" role="button"
               @click.prevent="updateFavs" aria-hidden="true"
               v-if="editMode" v-model="favs">
+              <strong class="fav-text">{{ favs }}</strong>
             </i>
             <div v-if="puffImage">
               <img :src="frameUrl(puffImage)" width="100px"/>
@@ -71,6 +72,7 @@ export default {
       puffContent: "",
       puffImage: "",
       favs: 0,
+      puffAuthor: "",
       userPuffs: [],
       puffsPage: 0,
       error: null,
@@ -97,7 +99,11 @@ export default {
       }
     },
     updateFavs() {
-      this.favs += 1;
+      if (this.$store.getters.getUserId === this.puffAuthor) {
+        this.favs = 1;
+      } else {
+        this.favs += 1;
+      }
     },
     success(message) {
       this.successMessage = message;
@@ -151,7 +157,8 @@ export default {
       this.puffTitle = puffObject.title;
       this.puffContent = puffObject.content;
       this.puffImage = puffObject.image;
-      if (puffObject.meta.favs) {
+      this.puffAuthor = puffObject.author;
+      if (puffObject.meta.favs > 0) {
         this.favs = puffObject.meta.favs;
       } else {
         this.favs = 0;
@@ -310,5 +317,11 @@ input {
 .fa-heart:hover {
   color: #d50000;
   cursor: pointer;
+}
+.fav-text {
+  font-family: "Roboto";
+  color: #000;
+  font-size: 14px;
+  padding: 0 10px 0 5px;
 }
 </style>

--- a/server/src/controllers/puffs/puff.js
+++ b/server/src/controllers/puffs/puff.js
@@ -65,7 +65,7 @@ exports.create = (req, res) => {
     content: req.body.content,
     tags: req.body.tags,
     comments: req.body.comments,
-    meta: req.body.meta,
+    favs: req.body.favs,
   };
   return Puff.create(puffData).then(puff => {
     if (puff) {
@@ -117,7 +117,7 @@ exports.update = (req, res) => {
       puff.content = req.body.content;
       puff.tags = req.body.tags;
       puff.comments = req.body.comments;
-      puff.meta = req.body.meta;
+      puff.favs = req.body.favs;
       puff.hidden = req.body.hidden;
       puff.save();
       res.status(200)
@@ -181,7 +181,7 @@ exports.createWithFile = (req, res) => {
     content: req.body.content,
     tags: req.body.tags,
     comments: req.body.comments,
-    meta: req.body.meta,
+    favs: req.body.favs,
     image: req.file.path,
   };
   return Puff.create(puffData).then(puff => {
@@ -234,7 +234,7 @@ exports.updateWithFile = (req, res) => {
       puff.content = req.body.content;
       puff.tags = req.body.tags;
       puff.comments = req.body.comments;
-      puff.meta = req.body.meta;
+      puff.favs = req.body.favs;
       puff.hidden = req.body.hidden;
       puff.image = req.file.path;
       puff.save();

--- a/server/src/controllers/puffs/router.js
+++ b/server/src/controllers/puffs/router.js
@@ -45,8 +45,8 @@ const multerUpload = Multer({
 export default express
   .Router()
   .post('/', validateToken, validatePuffSchema, puff.create)
-  .post('/u', validateToken, validatePuffSchema, multerUpload.single('upload'), puff.createWithFile)
-  .put('/u/:id', validateToken, validatePuffSchema, multerUpload.single('upload'), puff.updateWithFile)
+  .post('/u', validateToken, multerUpload.single('upload'), puff.createWithFile)
+  .put('/u/:id', validateToken, multerUpload.single('upload'), puff.updateWithFile)
   .put('/:id', validateToken, validatePuffSchema, puff.update)
   .get('/', validateToken, puff.list)
   .get('/:id', validateToken, puff.get)

--- a/server/src/models/puff.js
+++ b/server/src/models/puff.js
@@ -24,9 +24,8 @@ const PuffSchema = mongoose.Schema({
     type: Boolean,
     default: false,
   },
-  meta: {
-    votes: Number,
-    favs: Number,
+  favs: {
+    type: Number,
   },
   image: {
     type: String,

--- a/server/src/schemas/index.js
+++ b/server/src/schemas/index.js
@@ -11,6 +11,10 @@ exports.createUserSchema = (req, res, next) => {
     password: Joi.string().regex(
       new RegExp('^[a-zA-Z0-9]{8,32}$'),
     ),
+    admin: Joi.boolean(),
+    role: Joi.string(),
+    image: Joi.any(),
+    active: Joi.boolean(),
   };
   const {
     error,
@@ -56,6 +60,12 @@ exports.validatePuffSchema = (req, res, next) => {
   const schema = {
     title: Joi.string().required(),
     content: Joi.string().required(),
+    username: Joi.string(),
+    tags: Joi.any(),
+    comments: Joi.any(),
+    hidden: Joi.boolean(),
+    meta: Joi.any(),
+    image: Joi.any(),
   };
   const {
     error,

--- a/server/src/schemas/index.js
+++ b/server/src/schemas/index.js
@@ -64,7 +64,7 @@ exports.validatePuffSchema = (req, res, next) => {
     tags: Joi.any(),
     comments: Joi.any(),
     hidden: Joi.boolean(),
-    meta: Joi.any(),
+    favs: Joi.any(),
     image: Joi.any(),
   };
   const {


### PR DESCRIPTION
Following are the enhancements made,
1. If the logged in user is puff owner, then clicking on the heart icon will only increase the number up to 1. On the next click, it will decrement to 0. Works as a toggle icon for now.
2. Added a timeout of 5 seconds for all error messages display in the homepage as they are not disappearing until the page is refreshed.
3. Removed number display beside heart icon feed section and edit mode.
4. The color of the heart icon changes to red if favs = 1 and grey if favs = 0.