### PR TITLE
add image removal to the PUT/update method

### DIFF
--- a/server/src/controllers/puffs/puff.js
+++ b/server/src/controllers/puffs/puff.js
@@ -1,3 +1,4 @@
+import fs from 'fs-extra';
 import Puff from '../../models/puff';
 import User from '../../models/user';
 
@@ -113,6 +114,10 @@ exports.update = (req, res) => {
           message: 'Puff not Found',
         });
     } else {
+      if (puff.image && req.body.remove) {
+        fs.removeSync(puff.image);
+        puff.image = null;
+      }
       puff.title = req.body.title;
       puff.content = req.body.content;
       puff.tags = req.body.tags;

--- a/server/src/schemas/index.js
+++ b/server/src/schemas/index.js
@@ -66,6 +66,7 @@ exports.validatePuffSchema = (req, res, next) => {
     hidden: Joi.boolean(),
     favs: Joi.any(),
     image: Joi.any(),
+    remove: Joi.number(),
   };
   const {
     error,


### PR DESCRIPTION
Basically if the user decides to remove an image from a particular post/puff the front end needs to specify on a form of key `remove` and value `1`, this tell the code below to remove the picture from the `uploads` folder but only will do this as long as the puff has already have an `image`.  The `1` on the value is ignore by the code just put it there in case the front end and postman will require it.

Code added to PUT/Puff/update:
```
***
if (puff.image && req.body.remove) {
        fs.removeSync(puff.image);
        puff.image = null;
      }
***
```
To test:
Just do `git fetch --prune` then `git checkout feature/remove-image` or create a new branch from `development` then merge this branch after testing then delete this test branch..